### PR TITLE
Let programs output to file instead of stdout

### DIFF
--- a/scripts/run_in_file_program.sh
+++ b/scripts/run_in_file_program.sh
@@ -1,5 +1,12 @@
-set -e
+set -eu
 BASE_PATH=$(pwd)
-cd workspace/$CHALLENGE_NAME
-docker run --rm -v $BASE_PATH/challenges/$CHALLENGE_NAME/input.txt:/data/input.txt $CHALLENGE_NAME /data/input.txt  > result.txt
 
+cd workspace/$CHALLENGE_NAME
+rm -rf data/
+mkdir data/
+cp $BASE_PATH/challenges/$CHALLENGE_NAME/input.txt data/in.txt
+docker run --rm -v "$PWD/data/:/data/" $CHALLENGE_NAME /data/in.txt /data/out.txt > result.txt
+# Make sure old programs that use stdout and new programs using output file works.
+if [[ ! -s result.txt && -s data/out.txt ]]; then
+  mv data/out.txt result.txt;
+fi


### PR DESCRIPTION
## Issue
Currently we use `docker run ... > output` syntax to capture output of programs. I don't know exactly why but it's super slow compared to writing to a file in Docker volume, let alone out of Docker speed. Maybe it's related to Docker server-client protocol, maybe it's because of Docker log drivers.

I created two versions of my program, one that prints to stdout and one that writes to a file, the difference was huge (Numbers are for an AWS linux box).

```
Writing to stdout then redirect
real	0m6.540s
user	0m0.049s
sys	0m0.036s

Directly write to a file
real	0m1.296s
user	0m0.045s
sys	0m0.034s
```

When running the exact same file without Docker, both approaches gives similar result around `400ms` 🤷‍♂️.

If you're not sure about this you can use this 2 Docker files and see the difference.

```
FROM alpine
COPY expected.txt .
ENTRYPOINT cat expected.txt

real	0m5.758s
user	0m0.039s
sys	0m0.041s


FROM alpine
COPY expected.txt .
ENTRYPOINT cp expected.txt /data/out.txt

real	0m0.968s
user	0m0.053s
sys	0m0.027s
```

## Solution
I suggest to use a volume instead of stdout for now. Program will receive an additional argument that is the path of file to be created. My solution also works for older codes that prints to stdout instead of file.